### PR TITLE
fix: neutronjs codegen #ntrn-499

### DIFF
--- a/proto/slinky/oracle/v1/query.proto
+++ b/proto/slinky/oracle/v1/query.proto
@@ -39,10 +39,8 @@ service Query {
   // way to get the underlying currency pair from it.
   rpc GetCurrencyPairMappingList(GetCurrencyPairMappingListRequest)
       returns (GetCurrencyPairMappingListResponse) {
-    option (google.api.http) = {
-      get : "/connect/oracle/v2/get_currency_pair_mapping_list"
-      additional_bindings : []
-    };
+    option (google.api.http).get =
+        "/connect/oracle/v2/get_currency_pair_mapping_list";
   }
 }
 


### PR DESCRIPTION
additional_bindings = [] breaks telescope autogen, and it doesn't add anything useful, so we can remove it

https://hadronlabs.atlassian.net/browse/NTRN-499

PR's:
- [neutron-integration-tests](https://github.com/neutron-org/neutron-integration-tests/pull/384) - add ability to use eth signatures in tests, ability to randomly pick wallets with direct and eip191 signatures
- [neutronjsplus](https://github.com/neutron-org/neutronjsplus/pull/82) - add Eip191SigningCosmwasmClient to sign with ethereum wallets
- [neutronjs](https://github.com/neutron-org/neutronjs/pull/15) - add amino converters (to have ability for serializing tx messages into amino for ethereum signing)
- [slinky](https://github.com/neutron-org/connect/pull/2) - fixes codegen issue by removing unneeded additional_bindings